### PR TITLE
create braintree client just before using it

### DIFF
--- a/app/assets/javascripts/spree/braintree.js.coffee.erb
+++ b/app/assets/javascripts/spree/braintree.js.coffee.erb
@@ -8,11 +8,11 @@ processor = null
 $ ->
   # Verify the application has been configured and the braintree libraries are
   # loaded.
-  processor = new braintree.api.Client clientToken: braintree.clientToken if braintree? && braintree.clientToken
+  processor = new braintree.api.Client clientToken: braintreeClientToken if braintree? && braintreeClientToken
   return unless processor
 
   # Store device data in form for additional security
-  collector = braintree.data.setup kount: {environment: braintree.environment}
+  collector = braintree.data.setup kount: {environment: braintreeEnvironment}
   cc_fld('form', 'device_data').val collector.deviceData
   collector.teardown()
 
@@ -26,6 +26,7 @@ $(document).on 'submit', 'form#checkout_form_payment', (event) ->
     cvv: cc_val $this, "cvv"
     cardholderName: cc_val $this, "cardholder_name"
 
+  processor = new braintree.api.Client clientToken: braintreeClientToken
   processor.tokenizeCard card, (err, nonce) ->
     $this.data 'submitting', true
     cc_fld($this, 'payment_method_nonce').val nonce
@@ -42,6 +43,7 @@ $(document).on 'submit', '#checkout_form_confirm', (event) ->
 
   event.preventDefault()
 
+  processor = new braintree.api.Client clientToken: braintreeClientToken
   url = '<%= Rails.application.routes.url_helpers.braintree_payment_method_nonces_path %>'
   $.post url, {payment_method_id: fld.data('payment-method-id')}, (nonce)->
     processor.verify3DS amount: order_total, creditCard: nonce, (error, response) ->

--- a/app/views/spree/checkout/payment/_braintree_initialization.html.erb
+++ b/app/views/spree/checkout/payment/_braintree_initialization.html.erb
@@ -6,8 +6,8 @@ payment_method.provider
 <% content_for :head do %>
   <%= javascript_include_tag 'https://js.braintreegateway.com/js/braintree-2.17.6.min.js' %>
   <%= javascript_tag do %>
-    braintree.clientToken = "<%= Braintree::ClientToken.generate %>"
-    braintree.environment = "<%= payment_method.preferred_environment %>"
+    braintreeClientToken = "<%= Braintree::ClientToken.generate %>"
+    braintreeEnvironment = "<%= payment_method.preferred_environment %>"
   <% end %>
 <% end %>
 


### PR DESCRIPTION
when both spree_braintree_cse and spree_braintree_vzero are used, calling braintree.setup, from spree_braintree_vzero, it's invalidating the spree_braintree_cse client, so we need to reinstanciate it. hence we are deferring the client creation just before using it
