### PR TITLE
Update code so that device_data is used when vaulting

### DIFF
--- a/app/models/spree/gateway/braintree_gateway_decorator.rb
+++ b/app/models/spree/gateway/braintree_gateway_decorator.rb
@@ -46,14 +46,11 @@ Spree::Gateway::BraintreeGateway.class_eval do
     def authorize money, credit_card, options={}
       # Include device data if present
       options[:device_data] = credit_card.device_data
-
-      current_merchant_account_id = BraintreePresenter.new(credit_card.payment_method).merchant_account_id(money)
-      options[:merchant_account_id] = current_merchant_account_id
-      credit_card.payment_method.preferences[:merchant_account_id] = current_merchant_account_id
+      options[:merchant_account_id] = merchant_account_id credit_card.payment_method, money
 
       if (money.to_f / 100) >= credit_card.payment_method.preferred_three_d_threshold
         # Is expensive enough that three_d_secure should be used
-        options[:payment_method_nonce] = credit_card.encrypted_data
+        options[:payment_method_nonce] = true
         options[:three_d_secure] = { required: true }
 
         adjust_options_for_braintree credit_card, options
@@ -66,8 +63,15 @@ Spree::Gateway::BraintreeGateway.class_eval do
 
     # Adds device data when storing new card to prevent fraud
     def options_for_payment payment
-      super.merge_populated device_data: payment.source.device_data
-      super.merge_populated verification_merchant_account_id: BraintreePresenter.new(payment.payment_method).merchant_account_id(payment.amount.to_f * 100)
+      super.merge_populated \
+        device_data: payment.source.device_data,
+        verification_merchant_account_id: merchant_account_id(payment.payment_method, payment.amount.to_f * 100)
+    end
+
+    private
+
+    def merchant_account_id payment_method, amount
+      BraintreePresenter.new(payment_method).merchant_account_id(amount)
     end
   end
   prepend CardSecurity

--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -1,30 +1,64 @@
 Spree::Order.class_eval do
 
-  module CardSecurity
-    # Decorate how Spree processes the payment checkout form so that the card
-    # security information is communicated to the card. The model level uses
-    # this data to pass it onto braintree.
+  module CardSecurityOnVaulting
+    # When vaulting a card (i.e. moving from `payment` -> `confirm`) we want to
+    # provide the device_data to the records.
+    #
+    # Unlike the below decoration we cannot just find the payment records and
+    # add the info as the payment records don't yet exist (we are creating them
+    # via `super`). We cannot find the records and add the info AFTER `super`
+    # as the vaulting process happens during `super` (not during `order.next`).
+    #
+    # This means to give the info to the models we need to modify the params
+    # so that it is part of the nested attributes used to create the records.
     def update_from_params params, permitted_params, request_env = {}
-      # Run the standard behavior
-      success = super
+      if params[:device_data].present?
+        payment_attributes = params[:order][:payments_attributes] if params[:order]
+        if payment_attributes && payment_attributes.first
+          payment_method_id = payment_attributes.first[:payment_method_id]
+          params[:payment_source][payment_method_id][:device_data] = params[:device_data]
+        end
+      end
+
+      super
+    end
+  end
+  prepend CardSecurityOnVaulting
+
+  module CardSecuirtyOnTransaction
+    # When the checkout process moved forward between states it does two things
+    #
+    # * Updates the order with any info from the request (this method)
+    # * Calls `order.next` to transition to the next state
+    #
+    # Our goal with this decoration is to motify that first step to communicate
+    # the device data and 3D-secure data to the models so it is available for
+    # the second step to secure the transaction. This information is not saved
+    # to the database but just associated with the model in memory. This is
+    # enough as the `order.next` uses those same instances.
+    #
+    # This is really only intended for the `confirm` -> `complete` state but
+    # we don't actually check that as it doesn't hurt anything to run it on
+    # other transitions and keeps the code simpler by avoiding that check.
+    def update_from_params params, permitted_params, request_env = {}
+      # Run the standard behavior to update the order with the request info
+      ret = super
 
       # For each payment that might be processed......
       for payment in unprocessed_payments
 
-        # Let the payment know the device data for fraud prevention when
-        # actually processing the card. We already did this if we created a
-        # card but if we are using a saved card we need to do to do it here also
+        # Let the payment know the device data for fraud prevention
         payment.source.device_data = params[:device_data] if params[:device_data].present?
 
-        # So that the card is authorized with the secured nonce rather than just
-        # the unsecured payment profile token.
+        # Allow the card to be authorized with the secured nonce rather than
+        # just the unsecured payment profile token.
         payment.source.encrypted_data = params[:secured_nonce] if params[:secured_nonce].present?
       end
 
-      success
+      # Return the original response
+      ret
     end
-
   end
-  prepend CardSecurity
+  prepend CardSecuirtyOnTransaction
 
 end

--- a/lib/spree_braintree_cse/engine.rb
+++ b/lib/spree_braintree_cse/engine.rb
@@ -10,6 +10,8 @@ module Spree::BraintreeCSE
     end
 
     def self.activate
+      Spree::PermittedAttributes.source_attributes << :device_data
+
       Dir.glob(File.join(File.dirname(__FILE__), '../../app/**/*_decorator*.rb')) do |c|
         require_dependency c
       end


### PR DESCRIPTION
The device_data was found to not actually be used. 1eadcc9 corrected how the device_data was initialized in the client which fixed the problem for when transacting the order but we got word that the device_data still isn't being captured when the card is being vaulted.

This commit corrects this via several mechanisms:

* I found that the code which communicates the device data to the models works for the transaction but not for the vaulting because of the structure of the checkout process. To fix I created an additional decoration on  `update_from_params` which communicates the device data to the models on the payment stage. The necessitated adding `device_data` as a permitted param for source attributes.
* When the options are being built for vaulting the card the `options_for_payment` override was calling `super` twice rather than just merging both additional options in one line. This caused the first call (where the device data was merged in) to be ineffective.

In that last bullet point I also refactored the determination of the merchant_account_id into being a simple method call instead of the "presenter" object.

Finally there are two bits of code from 7daaded that seem to be wrong that were corrected:

* `options[:payment_method_nonce]` assignment was changed from `true` to the encrypted data. In the happy case (encrypted data provided) this was equal but in the case where CSE isn't being used it caused a error in an unobvious place. Restored just using `true` to make the cause of the error more obvious.
* There was an attempt to save the merchant id for the current transaction in the global spree preferences. This didn't make sense to me (or Martin) so I have removed it.